### PR TITLE
Feature/aioverrides

### DIFF
--- a/Scripts/AI/Actor.cs
+++ b/Scripts/AI/Actor.cs
@@ -155,6 +155,11 @@ public abstract class Actor : InputGenerator {
         }
     }
 
+    public void SetStartingAction(BaseAction startingAction)
+     {
+         this.startingAction = startingAction;
+     }
+
     public override void CleanUp() {
     }
 

--- a/Scripts/Characters/ActorOverride.cs
+++ b/Scripts/Characters/ActorOverride.cs
@@ -13,7 +13,7 @@ public class ActorOverride : MonoBehaviour
 
     public void ApplyActionOverride(InputGenerator inputGenerator)
     {
-        if (startingAction == null || inputGenerator is InputGeneratorPlayerPossession)
+        if (startingAction == null || inputGenerator == null || inputGenerator is InputGeneratorPlayerPossession)
             return;
 
         ((Actor)inputGenerator).SetStartingAction(startingAction);

--- a/Scripts/Characters/ActorOverride.cs
+++ b/Scripts/Characters/ActorOverride.cs
@@ -1,0 +1,35 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using AI;
+using AI.Actions;
+
+public class ActorOverride : MonoBehaviour
+{
+    [SerializeField, SerializeReference, SubclassSelector]
+    private BaseAction startingAction;
+    [SerializeField] private List<CharacterGroup> overrideGroups;
+    [SerializeField] private List<CharacterGroup> overrideUseByGroups;
+
+    public void ApplyActionOverride(InputGenerator inputGenerator)
+    {
+        if (startingAction == null || inputGenerator is InputGeneratorPlayerPossession)
+            return;
+
+        ((Actor)inputGenerator).SetStartingAction(startingAction);
+    }
+
+    public void ApplyGroupOverrides(CharacterBase character, List<CharacterGroup> defaultGroups, List<CharacterGroup> defaultUseByGroups)
+    {
+        List<CharacterGroup> newGroups = new List<CharacterGroup>(defaultGroups.Count + overrideGroups.Count);
+        newGroups.AddRange(defaultGroups);
+        newGroups.AddRange(overrideGroups);
+
+        List<CharacterGroup> newUseByGroups = new List<CharacterGroup>(defaultUseByGroups.Count + overrideUseByGroups.Count);
+        newUseByGroups.AddRange(defaultUseByGroups);
+        newUseByGroups.AddRange(overrideUseByGroups);
+
+        character.SetGroups(newGroups);
+        character.SetUseByGroups(newUseByGroups);
+    }
+}

--- a/Scripts/Characters/ActorOverride.cs.meta
+++ b/Scripts/Characters/ActorOverride.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: af8dd97149904f2468ea0b6b868fc238
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Characters/CharacterSpawnInfo.cs
+++ b/Scripts/Characters/CharacterSpawnInfo.cs
@@ -10,6 +10,7 @@ public class CharacterSpawnInfo {
     [SerializeField,SerializeReference,SubclassSelector] private InputGenerator inputSource;
     [SerializeField] private List<CharacterGroup> overrideGroups;
     [SerializeField] private List<CharacterGroup> overrideUseByGroups;
+    [SerializeField] private OverrideLocks overrideLocks;
     private AsyncOperationHandle<Civilian> handle;
     
     public AsyncOperationHandle<Civilian> GetCharacter() {
@@ -37,6 +38,16 @@ public class CharacterSpawnInfo {
         if (obj.Result is not Civilian characterBase) {
             throw new UnityException("Loaded a non-civilian as a character! Characters must have it as a behavior!");
         }
+
+        if (characterBase.gameObject.TryGetComponent(out ActorOverride overrides))
+        {
+            if ((overrideLocks.Locks & (1 << 0)) != 1)
+                overrides.ApplyActionOverride(inputSource);
+
+            if ((overrideLocks.Locks & (1 << 1)) != 1)
+                overrides.ApplyGroupOverrides(characterBase, overrideGroups, overrideUseByGroups);
+        }
+
         characterBase.SetInputGenerator(inputSource);
         characterBase.SetGroups(overrideGroups);
         characterBase.SetUseByGroups(overrideUseByGroups);

--- a/Scripts/Characters/CharacterSpawnInfo.cs
+++ b/Scripts/Characters/CharacterSpawnInfo.cs
@@ -39,18 +39,29 @@ public class CharacterSpawnInfo {
             throw new UnityException("Loaded a non-civilian as a character! Characters must have it as a behavior!");
         }
 
+        bool assignedGroups = false;
+
         if (characterBase.gameObject.TryGetComponent(out ActorOverride overrides))
         {
-            if ((overrideLocks.Locks & (1 << 0)) != 1)
+            bool actionLocked = (overrideLocks.Locks & (1 << 0)) == (1 << 0);
+            bool groupsLocked = (overrideLocks.Locks & (1 << 1)) == (1 << 1);
+
+            if (!actionLocked)
                 overrides.ApplyActionOverride(inputSource);
 
-            if ((overrideLocks.Locks & (1 << 1)) != 1)
+            if (!groupsLocked)
+            {;
                 overrides.ApplyGroupOverrides(characterBase, overrideGroups, overrideUseByGroups);
+                assignedGroups = true;
+            }
         }
 
         characterBase.SetInputGenerator(inputSource);
-        characterBase.SetGroups(overrideGroups);
-        characterBase.SetUseByGroups(overrideUseByGroups);
+        if(!assignedGroups)
+        {
+            characterBase.SetGroups(overrideGroups);
+            characterBase.SetUseByGroups(overrideUseByGroups);
+        }
     }
 
 }

--- a/Scripts/Characters/OverrideLocks.cs
+++ b/Scripts/Characters/OverrideLocks.cs
@@ -11,6 +11,7 @@ public class OverrideLocks
     public int Locks => enabledLocks;
 }
 
+#if UNITY_EDITOR
 [CustomPropertyDrawer(typeof(OverrideLocks))]
 public class MultiSelectExampleDrawer : PropertyDrawer
 {
@@ -30,3 +31,4 @@ public class MultiSelectExampleDrawer : PropertyDrawer
         }
     }
 }
+#endif

--- a/Scripts/Characters/OverrideLocks.cs
+++ b/Scripts/Characters/OverrideLocks.cs
@@ -1,0 +1,32 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEditor;
+
+[System.Serializable]
+public class OverrideLocks
+{
+    [SerializeField] private int enabledLocks;
+
+    public int Locks => enabledLocks;
+}
+
+[CustomPropertyDrawer(typeof(OverrideLocks))]
+public class MultiSelectExampleDrawer : PropertyDrawer
+{
+    private readonly string[] options = { "Starting Action", "Override Groups" };
+
+    public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+    {
+        SerializedProperty locksProperty = property.FindPropertyRelative("enabledLocks");
+
+        if (locksProperty != null)
+        {
+            locksProperty.intValue = EditorGUI.MaskField(position, label, locksProperty.intValue, options);
+        }
+        else
+        {
+            EditorGUI.LabelField(position, label.text, "Expected 'enabledLocks' field not found.");
+        }
+    }
+}

--- a/Scripts/Characters/OverrideLocks.cs.meta
+++ b/Scripts/Characters/OverrideLocks.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b66b591ae5aaf8349b641ac080b41f59
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Yep, it's me again.

This feature is for overriding AI actions/groups inside mods themselves, giving players more control over the character replacements. The main features include:

ActorOverride - An optional monobehaviour script that allows a modder to define the starting action, override groups, and use by groups of a character.

OverrideLocks - A set of flags added to CharacterLoaders which, when activated, prevent the starting action or groups from being changed by mods. (These are off by default)

For the sake of not breaking zoning, all existing groups are preserved, and the groups selected by the mod are simply added to the list.


In regards to the discussion in the discord, I have done some testing, and not yet found any major issues in regards to mod compatibility. I've tried old maps and old mods while running this code with no issue, and I've tried switching off this branch, using a character mod built with the custom script, and only experienced the standard unity missing script warnings.

I used this unlisted workshop mod for testing: https://steamcommunity.com/sharedfiles/filedetails/?id=3476246107

It is a character replacer with an ActorOverride attached to the prefab (Top level, same object as the civilian script). While it just replaces the CivilianRat when running off a different branch or in the base game, testing it in a unity environment on this branch replaces the behaviour as expected.

I'll likely try to do some more testing in the next couple days, but in the meantime I wanted to send this your way for review if you get the chance.

Thank you for your time!